### PR TITLE
Lizenztexte verlinkt

### DIFF
--- a/map/js/common.js
+++ b/map/js/common.js
@@ -74,3 +74,23 @@ function getQueryParameter() {
 
 		return vars;
 }
+
+var licenseUrls = {
+	"By Ubahnverleih (Own work) [CC BY 3.0 (http://creativecommons.org/licenses/by/3…" : "https://creativecommons.org/licenses/by/3.0/deed.de",
+	"By ubahnverleih (Own work) [CC0], via Wikimedia Commons" : "https://creativecommons.org/publicdomain/zero/1.0/deed.de",
+	"CC BY 3.0" : "https://creativecommons.org/licenses/by/3.0/deed.de",
+	"CC BY-NC 4.0 International" : "https://creativecommons.org/licenses/by-nc/4.0/deed.de",
+	"CC BY-NC-SA 3.0 DE" : "https://creativecommons.org/licenses/by-nc-sa/3.0/de/deed.de",
+	"CC BY-SA 4.0" : "https://creativecommons.org/licenses/by-sa/4.0/deed.de",
+	"CC0 1.0 Universell (CC0 1.0)" : "http://creativecommons.org/publicdomain/zero/1.0/deed.de"
+};
+
+/**
+ * Gibt die URL zum Lizenttext zurück
+ * 
+ * @param {string} licenseName interner Name der Lizenz
+ * @return {string} die URL zum Lizenztext
+ */
+function getLicenseUrlForLicenseName(licenseName) {
+	return licenseUrls[licenseName];
+}

--- a/map/js/main.js
+++ b/map/js/main.js
@@ -10,6 +10,16 @@ var dataBahnhoefe = null,
 	countries = null,
 	nickname;
 
+var licenseUrls = {
+	"By Ubahnverleih (Own work) [CC BY 3.0 (http://creativecommons.org/licenses/by/3…" : "https://creativecommons.org/licenses/by/3.0/deed.de",
+	"By ubahnverleih (Own work) [CC0], via Wikimedia Commons" : "https://creativecommons.org/publicdomain/zero/1.0/deed.de",
+	"CC BY 3.0" : "https://creativecommons.org/licenses/by/3.0/deed.de",
+	"CC BY-NC 4.0 International" : "https://creativecommons.org/licenses/by-nc/4.0/deed.de",
+	"CC BY-NC-SA 3.0 DE" : "https://creativecommons.org/licenses/by-nc-sa/3.0/de/deed.de",
+	"CC BY-SA 4.0" : "https://creativecommons.org/licenses/by-sa/4.0/deed.de",
+	"CC0 1.0 Universell (CC0 1.0)" : "http://creativecommons.org/publicdomain/zero/1.0/deed.de"
+};
+
 function showMap() {
 	"use strict";
 
@@ -25,7 +35,8 @@ function showPopup(feature, layer) {
 	if (null !== feature.properties.photographer) {
 		var photoURL = scaleImage(feature.properties.photoUrl, 301);
 		str += "<a href=\"" + detailLink + "\" class=\"localLink\" style=\"display: block; max-height: 200px; overflow: hidden;\"><img src=\"" + photoURL + "\" style=\"width:301px;\" height=\"400\"></a><br>";
-		str += "<div style=\"text-align:right;\">Fotograf: <a href=\"" + feature.properties.photographerUrl + "\">" + feature.properties.photographer + "</a>, Lizenz: " + feature.properties.license + "</div>";
+		str += "<div style=\"text-align:right;\">Fotograf: <a href=\"" + feature.properties.photographerUrl + "\">" + feature.properties.photographer + "</a>, "
+		str += "Lizenz: <a href=\"" + licenseUrls[feature.properties.license] + "\">" + feature.properties.license + "</a></div>"
 		str += "<h1 style=\"text-align:center;\"><a href=\"" + detailLink + "\" class=\"localLink\">" + feature.properties.title + "</a></h1>";
 	} else {
 		str += "<a href=\"" + detailLink + "\" class=\"localLink\"><h1 style=\"text-align:center;\">" + feature.properties.title + "</h1></a>";

--- a/map/js/main.js
+++ b/map/js/main.js
@@ -10,16 +10,6 @@ var dataBahnhoefe = null,
 	countries = null,
 	nickname;
 
-var licenseUrls = {
-	"By Ubahnverleih (Own work) [CC BY 3.0 (http://creativecommons.org/licenses/by/3…" : "https://creativecommons.org/licenses/by/3.0/deed.de",
-	"By ubahnverleih (Own work) [CC0], via Wikimedia Commons" : "https://creativecommons.org/publicdomain/zero/1.0/deed.de",
-	"CC BY 3.0" : "https://creativecommons.org/licenses/by/3.0/deed.de",
-	"CC BY-NC 4.0 International" : "https://creativecommons.org/licenses/by-nc/4.0/deed.de",
-	"CC BY-NC-SA 3.0 DE" : "https://creativecommons.org/licenses/by-nc-sa/3.0/de/deed.de",
-	"CC BY-SA 4.0" : "https://creativecommons.org/licenses/by-sa/4.0/deed.de",
-	"CC0 1.0 Universell (CC0 1.0)" : "http://creativecommons.org/publicdomain/zero/1.0/deed.de"
-};
-
 function showMap() {
 	"use strict";
 
@@ -36,7 +26,7 @@ function showPopup(feature, layer) {
 		var photoURL = scaleImage(feature.properties.photoUrl, 301);
 		str += "<a href=\"" + detailLink + "\" class=\"localLink\" style=\"display: block; max-height: 200px; overflow: hidden;\"><img src=\"" + photoURL + "\" style=\"width:301px;\" height=\"400\"></a><br>";
 		str += "<div style=\"text-align:right;\">Fotograf: <a href=\"" + feature.properties.photographerUrl + "\">" + feature.properties.photographer + "</a>, "
-		str += "Lizenz: <a href=\"" + licenseUrls[feature.properties.license] + "\">" + feature.properties.license + "</a></div>"
+		str += "Lizenz: <a href=\"" + getLicenseUrlForLicenseName(feature.properties.license) + "\">" + feature.properties.license + "</a></div>"
 		str += "<h1 style=\"text-align:center;\"><a href=\"" + detailLink + "\" class=\"localLink\">" + feature.properties.title + "</a></h1>";
 	} else {
 		str += "<a href=\"" + detailLink + "\" class=\"localLink\"><h1 style=\"text-align:center;\">" + feature.properties.title + "</h1></a>";

--- a/map/js/photographer.js
+++ b/map/js/photographer.js
@@ -26,7 +26,7 @@ $(document).ready(function () {
 					$("#stations").append("<div class=\"station\">" +
 						"<h1><a href=\"" + detailLink + "\" class=\"localLink\">" + obj[i].title + "</a></h1>" +
 						"<div><a href=\"" + detailLink + "\" class=\"localLink\" style=\"display: block; max-height: 200px; overflow: hidden;\"><img src=\"" + photoURL + "\" style=\"width:301px;\" height=\"400\"></a></div>" +
-						"<div>Lizenz: " + obj[i].license + "</div>" +
+						"<div>Lizenz: <a href=\"" + getLicenseUrlForLicenseName(obj[i].license) + "\">" + obj[i].license + "</a></div>" +
 						"</div>");
 				}
 			} else {

--- a/map/station.php
+++ b/map/station.php
@@ -30,6 +30,15 @@
 	    $photoCaption = 'Fehler beim Laden der Station';
 	}
 
+	$licenseUrls = [
+		"By Ubahnverleih (Own work) [CC BY 3.0 (http://creativecommons.org/licenses/by/3…" => "https://creativecommons.org/licenses/by/3.0/deed.de",
+		"By ubahnverleih (Own work) [CC0], via Wikimedia Commons" => "https://creativecommons.org/publicdomain/zero/1.0/deed.de",
+		"CC BY 3.0" => "https://creativecommons.org/licenses/by/3.0/deed.de",
+		"CC BY-NC 4.0 International" => "https://creativecommons.org/licenses/by-nc/4.0/deed.de",
+		"CC BY-NC-SA 3.0 DE" => "https://creativecommons.org/licenses/by-nc-sa/3.0/de/deed.de",
+		"CC BY-SA 4.0" => "https://creativecommons.org/licenses/by-sa/4.0/deed.de",
+		"CC0 1.0 Universell (CC0 1.0)" => "http://creativecommons.org/publicdomain/zero/1.0/deed.de"
+	];
 ?>
 <!DOCTYPE html>
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="de-DE"> <![endif]-->
@@ -91,7 +100,10 @@
     <section id="main" class="container detail clearfix">
 			<div>
 				<img id="station-photo" src="<?php echo htmlspecialchars($stationPhoto);?>" title="<?php echo htmlspecialchars($photoCaption);?>"/>
-				<div id="photo-caption">Fotograf: <a href="<?php echo htmlspecialchars($photographerUrl);?>" id="photographer-url"><span id="photographer"><?php echo htmlspecialchars($photographer);?></span></a>, Lizenz: <span id="license"><?php echo htmlspecialchars($license);?></span></div>
+				<div id="photo-caption">
+					Fotograf: <a href="<?php echo htmlspecialchars($photographerUrl);?>" id="photographer-url"><span id="photographer"><?php echo htmlspecialchars($photographer);?></span></a>, 
+					Lizenz: <a href="<?php echo htmlspecialchars($licenseUrls[$license]);?>" id="license-url"><span id="license"><?php echo htmlspecialchars($license);?></span></a>
+				</div>
 			</div>
     </section>
   </body>


### PR DESCRIPTION
Von den Namen der Lizenzen werden die URLs zu den Lizenztexten abgeleitet. Es gibt eine entsprechende Map in `station.php` und in `common.js`. Ich hatte keine Idee, wie sich das zusammenfassen ließe.
An diesen Stellen werden die Lizenztexte jetzt verlinkt:
- In der Fotoansicht des Bahnhofs (`station.php`)
- Im Popup auf der Map (`main.js`)
- In der Fotografen-Ansicht (`photographer.js`)